### PR TITLE
Fix link to rustaceans.org

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -170,7 +170,7 @@
         </div>
     </div>
 
-    <a href=//www.rustaceans.org/">Go here for actual rustaceans.</a>
+    <a href="//www.rustaceans.org/">Go here for actual rustaceans.</a>
 
     <div class="license">
         <p xmlns:dct="//purl.org/dc/terms/" xmlns:vcard="//www.w3.org/2001/vcard-rdf/3.0#">


### PR DESCRIPTION
Without this change, the link was to `https://www.rustaceans.org/"`.