### PR TITLE
Fix merchandise links

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -96,11 +96,11 @@
                 </a>
             </div>
             <div>
-                <a href="//teespring.com/rustacean-two">
+                <a href="//rustaceans.creator-spring.com/listing/rustacean?product=369">
                     <img src="more-crabby-things/rustacean-shirt-2.png"/>
                 </a>
                 <p>
-                    <a href="//teespring.com/stores/rustaceans">Rustacean merchandise</a>
+                    <a href="//rustaceans.creator-spring.com">Rustacean merchandise</a>
                 </p>
             </div>
             <div>


### PR DESCRIPTION
The old image link is 404 and the 404 page shows sometimes-sketchy results. The exact same T-shirt isn't available any more, so I redirected to the closest match in the store.