### PR TITLE
Fix t-shirt link typo

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -128,7 +128,7 @@
               </div>
               <div>
                 <a
-                  href="hhttps://rustaceans.creator-spring.com/listing/new-ferris-the-rustacean?product=46&variation=6578"
+                  href="https://rustaceans.creator-spring.com/listing/new-ferris-the-rustacean?product=46&variation=6578"
                 >
                   <img src="more-crabby-things/ferris-shirt.png" />
                   <p>Rustacean shirts</p>


### PR DESCRIPTION
There's a typo in the "Rustacean shirts" link, here's a quick PR to fix it by removing the extra 'h'